### PR TITLE
Use HW transform instead of SW rotation for VDU

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -451,12 +451,15 @@ display:
   platform: ili9xxx
   id: vdu
   model: ST7789V
-  rotation: 90
+  transform: 
+    swap_xy: True
+    mirror_x: True
+    mirror_y: False
   dimensions:
-    height: 240
-    width: 135
-    offset_height: 40
-    offset_width: 52
+    width: 240
+    height: 135
+    offset_width: 40
+    offset_height: 52
   dc_pin: GPIO06
   cs_pin: GPIO12
   invert_colors: true


### PR DESCRIPTION
As per https://esphome.io/components/display/ili9xxx.html , 'transform' is done in hardware, and so is preferred to 'rotation' which is done in software.

Updates the configuration so the rotation is done via 'transform', and updates the dimensions to match. No other changes needed AFAICT.